### PR TITLE
Add 'stop()' method to enable stubby server to be shutdown programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ gulp.task('stubby', function(cb) {
         files: [
             'mocks/*.{json,yaml,js}'
         ]
-    }; 
+    };
     stubby(options, cb);
 });
 ```
@@ -137,6 +137,15 @@ Default value: `false`
 
 Run the task in a persistent keep-alive server mode. Other tasks not will run until the Stubby server stops
 
+## API
+
+#### stop
+Allows you to programmatically shutdown the stubby server.
+
+```
+stubbyServer.stop();
+```
+
 ## Contributing
 
 In lieu of a formal styleguide, take care to maintain the existing coding style.
@@ -171,7 +180,7 @@ $ npm test
 
 * `0.1.1` 27.11.2014
   - Changes repository name
-  
+
 * `0.1.0` 27.11.2014
   - Initial release
 

--- a/index.js
+++ b/index.js
@@ -184,6 +184,13 @@ function stubbyPlugin(customOptions, cb) {
         });
     }
 
+    return {
+        stop: function() {
+            gutil.log(gutil.colors.green('Stubby server stopped'));
+            stubbyServer.stop();
+        }
+    }
+
 }
 
 module.exports = stubbyPlugin;

--- a/index.js
+++ b/index.js
@@ -186,8 +186,8 @@ function stubbyPlugin(customOptions, cb) {
 
     return {
         stop: function() {
-            gutil.log(gutil.colors.green('Stubby server stopped'));
             stubbyServer.stop();
+            gutil.log(gutil.colors.green('Stubby server stopped'));
         }
     }
 


### PR DESCRIPTION
Reason for this change is that when running tests in a CI environment we found that the stubby server stays running after tests complete. The next time we checked into the repository and tests ran on our CI box, stubby would not start as it was already running.

We are using `run-sequence` to run gulp tasks in order:
- task 1 for starting stubby server
- task 2 for running tests
- task 3 for stopping stubby server programmatically via this new method