### PR TITLE
FIX event-stream 3.3.6 vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "supertest": "~0.7.1"
   },
   "dependencies": {
-    "event-stream": "^3.1.7",
+    "event-stream": "3.3.4",
     "glob-all": "^3.0.3",
     "gulp": "^3.9.0",
     "gulp-util": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-stubby-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Gulp plugin for setting up a Stubby mock server based on YAML/JSON/JS configuration files",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Event-stream 3.3.6 add malicious code the 3.3.4 version is the last good version.

This should be fix as soon as possible. 

https://thehackernews.com/2018/11/nodejs-event-stream-module.html